### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers, remove conda-forge/napari team

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,6 @@ Feedstock Maintainers
 =====================
 
 * [@alisterburt](https://github.com/alisterburt/)
-* [@conda-forge/napari](https://github.com/conda-forge/napari/)
+* [@goanpeca](https://github.com/goanpeca/)
+* [@jaimergp](https://github.com/jaimergp/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,4 +48,5 @@ about:
 extra:
   recipe-maintainers:
     - alisterburt
-    - conda-forge/napari
+    - goanpeca
+    - jaimergp


### PR DESCRIPTION
The `conda-forge/napari` team was initially added as a way to support the migration to conda-forge.

The situation is now stable and we can prevent unwanted notifications by only leaving a subset of the team listed explicitly as maintainers.